### PR TITLE
Fixed bool reference with numpy 1.26.0

### DIFF
--- a/src/munkres.pyx
+++ b/src/munkres.pyx
@@ -29,7 +29,7 @@ def munkres(np.ndarray[np.double_t,ndim=2, mode="c"] A not None):
     cdef Munkres* munk = new Munkres()
     munk.solve(<double *> A.data, <int *> rslt.data, x, y)
     del munk
-    return rslt.astype(np.bool)
+    return rslt.astype(np.bool_)
 
 @cython.boundscheck(False)
 def max_cost_munkres(np.ndarray[np.double_t,ndim=2] A not None, double max_cost):
@@ -61,7 +61,7 @@ def iterative_munkres(np.ndarray[np.double_t,ndim=2] icost, max_cost):
         dim = np.delete(dim, remove, 0)
         if cost.shape[1] == 0 or not np.any(r):
             done = True
-    return assigned.astype(np.bool)
+    return assigned.astype(np.bool_)
 
 @cython.boundscheck(False)
 def _get_cost(np.ndarray[np.int_t, ndim=1] x, np.ndarray[np.int_t, ndim=1] y, np.ndarray[np.double_t, ndim=2] C):


### PR DESCRIPTION
Alternatively, the builtin bool object can be used.